### PR TITLE
EdilKamin breaking API update

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "git+https://github.com/AndreMiras/edilkamin.js.git"
   },
   "author": "Andre Miras",
+  "contributors": [
+    { "name": "Maxime Journaux", "email": "maxime.journaux@espridigital.fr" }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/AndreMiras/edilkamin.js/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edilkamin",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edilkamin",
-  "version": "1.6.0",
+  "version": "1.5.0",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -25,9 +25,6 @@
     "url": "git+https://github.com/AndreMiras/edilkamin.js.git"
   },
   "author": "Andre Miras",
-  "contributors": [
-    { "name": "Maxime Journaux", "email": "maxime.journaux@espridigital.fr" }
-  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/AndreMiras/edilkamin.js/issues"
@@ -61,7 +58,7 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "mocha": "^10.8.2",
     "nyc": "^17.1.0",
-    "prettier": "^3.0.0",
+    "prettier": "^2.5.1",
     "sinon": "^19.0.2",
     "ts-node": "^10.9.1",
     "typedoc": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "mocha": "^10.8.2",
     "nyc": "^17.1.0",
-    "prettier": "^2.5.1",
+    "prettier": "^3.0.0",
     "sinon": "^19.0.2",
     "ts-node": "^10.9.1",
     "typedoc": "^0.27.2",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
 const API_URL =
-  "https://fxtj7xkgc6.execute-api.eu-central-1.amazonaws.com/prod/";
+  "https://the-mind-api.edilkamin.com/";
 
 export { API_URL };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,3 @@
-const API_URL =
-  "https://the-mind-api.edilkamin.com/";
+const API_URL = "https://the-mind-api.edilkamin.com/";
 
 export { API_URL };

--- a/src/library.test.ts
+++ b/src/library.test.ts
@@ -29,7 +29,7 @@ describe("library", () => {
       const signOut = sinon.stub();
       const fetchAuthSession = sinon.stub().resolves({
         tokens: {
-          accessToken: { toString: () => expectedToken },
+          idToken: { toString: () => expectedToken },
         },
       });
       const authStub = {

--- a/src/library.ts
+++ b/src/library.ts
@@ -52,7 +52,8 @@ const createAuthService = (auth: typeof amplifyAuth) => {
     assert.ok(isSignedIn, "Sign-in failed");
     const { tokens } = await auth.fetchAuthSession();
     assert.ok(tokens, "No tokens found");
-    return tokens.accessToken.toString();
+    assert.ok(tokens.idToken, "No ID token found");
+    return tokens.idToken.toString();
   };
   return { signIn };
 };


### PR DESCRIPTION
See: https://github.com/AndreMiras/edilkamin.py/issues/9

Mail from EdilKamin to notify major app update : 

> Dear Customer,
>
>we would like to inform you that an important update of the THE MIND app is now available, necessary to ensure its correct operation.
>The update can be downloaded from your smartphone’s store (App Store for iPhone/iPad and Play Store for Android devices).
>
>🔺 Required update:
>previous versions of the app may not function properly until the update is installed.
>
>In the next few days, due to normal system stabilization operations, some occasional errors may occur.
>The situation will return to normal as soon as possible.
>
>Kind regards,
>
>Please do not reply to this email (no-reply)
>After Sales Service
>Edilkamin S.p.A.

EdilKamin released a major app/API update. The EdilKamin API now requires an id_token from Cogito / aws-amplify for authentication instead of the access_token.

This PR updates the API client to use id_token and includes minor dev dependency and package version updates.

Changes
🔧 Fix: authentication flow updated to use id_token (instead of access_token).
📦 Update dev dependency prettier.
🆙 Package version bumped.